### PR TITLE
Add sample pages with futuristic navigation button

### DIFF
--- a/src/components/FuturisticButton.tsx
+++ b/src/components/FuturisticButton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+const VALID_ROUTES = ['/', '/about', '/contact'];
+
+interface FuturisticButtonProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+const FuturisticButton: React.FC<FuturisticButtonProps> = ({ href, children }) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (VALID_ROUTES.includes(href)) {
+      router.push(href);
+    } else {
+      console.error(`Attempted navigation to unknown route: ${href}`);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      style={{
+        padding: '12px 24px',
+        borderRadius: '8px',
+        border: 'none',
+        background: 'linear-gradient(135deg, #00d2ff 0%, #3a7bd5 100%)',
+        color: '#fff',
+        fontSize: '16px',
+        cursor: 'pointer',
+        boxShadow: '0 0 8px rgba(58,123,213,0.6)',
+        transition: 'transform 0.2s, box-shadow 0.2s',
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.boxShadow = '0 0 16px rgba(58,123,213,0.9)';
+        (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1.05)';
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.boxShadow = '0 0 8px rgba(58,123,213,0.6)';
+        (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1)';
+      }}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default FuturisticButton;

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import FuturisticButton from '../components/FuturisticButton';
+
+const AboutPage: React.FC = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '40px' }}>
+      <h1>About This Blog</h1>
+      <p style={{ marginTop: '16px' }}>
+        This is a demo blog showcasing navigation using a futuristic button.
+      </p>
+      <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', marginTop: '24px' }}>
+        <FuturisticButton href="/">Home</FuturisticButton>
+        <FuturisticButton href="/contact">Contact</FuturisticButton>
+      </div>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import FuturisticButton from '../components/FuturisticButton';
+
+const ContactPage: React.FC = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '40px' }}>
+      <h1>Contact</h1>
+      <p style={{ marginTop: '16px' }}>
+        You can reach us by clicking the buttons below.
+      </p>
+      <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', marginTop: '24px' }}>
+        <FuturisticButton href="/">Home</FuturisticButton>
+        <FuturisticButton href="/about">About</FuturisticButton>
+      </div>
+    </div>
+  );
+};
+
+export default ContactPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import FuturisticButton from '../components/FuturisticButton';
+
+const HomePage: React.FC = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '40px' }}>
+      <h1>Welcome to the AI Blog</h1>
+      <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', marginTop: '24px' }}>
+        <FuturisticButton href="/about">Go to About</FuturisticButton>
+        <FuturisticButton href="/contact">Contact Us</FuturisticButton>
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- add FuturisticButton component with route validation
- add home, about, and contact pages using the component for navigation

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b81447dbc8330a076eee967b9a7b6